### PR TITLE
Fix grid

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "glucotrack-ui",
-  "version": "3.3.2",
+  "version": "3.3.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "glucotrack-ui",
-      "version": "3.3.2",
+      "version": "3.3.4",
       "dependencies": {
         "@clerk/clerk-react": "^5.43.0",
         "@clerk/themes": "^2.4.12",
@@ -10576,20 +10576,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
-    },
-    "node_modules/yaml": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.6.1.tgz",
-      "integrity": "sha512-7r0XPzioN/Q9kXBro/XPnA6kznR73DHq+GXh5ON7ZozRO6aMjbmiBuKste2wslTFkC5d1dw0GooOCepZXJ2SAg==",
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/src/components/measurements/MeasurementForm.tsx
+++ b/src/components/measurements/MeasurementForm.tsx
@@ -16,7 +16,7 @@ import {
   ChevronRight,
   ChevronLeft,
 } from "@mui/icons-material"
-import { Grid } from "@mui/material"
+import Grid from "@mui/material/Grid2"
 import { setFilter } from "@/components/measurements/measurementsSlice"
 import dayjs from "dayjs"
 import utc from "dayjs/plugin/utc"
@@ -347,8 +347,8 @@ const MeasurementForm = ({
               deviceNamesFromGroup.length > 0
                 ? deviceNamesFromGroup
                 : deviceNames && deviceNames.length > 0
-                  ? deviceNames
-                  : [],
+                ? deviceNames
+                : [],
             groupName: groupName ? groupName : "",
             startTime: utcStartTime,
             endTime: utcEndTime,
@@ -425,8 +425,8 @@ const MeasurementForm = ({
   return (
     <Box sx={{ flexGrow: 1 }}>
       <form onSubmit={handleSaveFilter} style={{ marginBottom: 20 }}>
-        <Grid container xs={12}>
-          <Grid xs={9}>
+        <Grid container size={12}>
+          <Grid size={9}>
             <Grid alignItems={"center"} container>
               <TextField
                 label="Save filter as"
@@ -440,7 +440,7 @@ const MeasurementForm = ({
             </Grid>
           </Grid>
 
-          <Grid xs={3}>
+          <Grid size={3}>
             <Autocomplete
               options={savedFilters ? savedFilters : []}
               value={selectedFilter}
@@ -485,8 +485,8 @@ const MeasurementForm = ({
 
       <form onSubmit={handleSubmit}>
         <Grid container spacing={4} alignItems={"start"}>
-          <Grid container xs={8} spacing={2}>
-            <Grid xs={groupData ? 5 : 12}>
+          <Grid container size={8} spacing={2}>
+            <Grid size={groupData ? 5 : 12}>
               <Autocomplete
                 multiple
                 loading={deviceIsLoading || deviceIsFetching}
@@ -508,7 +508,7 @@ const MeasurementForm = ({
             </Grid>
             {groupData && (
               <>
-                <Grid xs={2}>
+                <Grid size={2}>
                   <Box
                     sx={{
                       display: "flex",
@@ -520,7 +520,7 @@ const MeasurementForm = ({
                     OR
                   </Box>
                 </Grid>
-                <Grid xs={5}>
+                <Grid size={5}>
                   <Autocomplete
                     loading={groupIsLoading || groupIsFetching}
                     options={groupName ? groupName : []}
@@ -541,12 +541,12 @@ const MeasurementForm = ({
               </>
             )}
 
-            <Grid xs={1} alignContent={"center"}>
+            <Grid size={1} alignContent={"center"}>
               <IconButton onClick={handleBack}>
                 <ChevronLeft />
               </IconButton>
             </Grid>
-            <Grid xs={5}>
+            <Grid size={5}>
               <TextField
                 label="Start Time"
                 type="datetime-local"
@@ -564,7 +564,7 @@ const MeasurementForm = ({
                 }}
               />
             </Grid>
-            <Grid xs={5}>
+            <Grid size={5}>
               {!formValues.realtime && (
                 <TextField
                   label="End Time"
@@ -583,15 +583,13 @@ const MeasurementForm = ({
                 />
               )}
             </Grid>
-            <Grid xs={1} alignContent={"center"}>
+            <Grid size={1} alignContent={"center"}>
               <IconButton onClick={handleForward}>
                 <ChevronRight />
               </IconButton>
             </Grid>
-
-            <Grid xs={12}></Grid>
           </Grid>
-          <Grid xs={4}>
+          <Grid size={4}>
             <Grid container spacing={1}>
               <Grid>
                 <Button


### PR DESCRIPTION
This pull request updates the `MeasurementForm` component to use the `Grid2` layout system from MUI, replacing the older `Grid` usage. The main changes involve updating import statements and replacing the `xs` prop with the `size` prop throughout the component to ensure compatibility with the new grid system.

**Migration to MUI Grid2:**

* Changed the import from `@mui/material/Grid` to `@mui/material/Grid2` and updated all usages in `MeasurementForm.tsx` to use the new `Grid2` component.
* Replaced all instances of the `xs` prop with the `size` prop in `Grid` components to match the API of `Grid2`. This includes updating layout definitions for containers and items throughout the form. [[1]](diffhunk://#diff-cedf94f97f1e32ff05bb71a4ebf72d9b1075f04117fa39e64ee3b513f6e48685L428-R429) [[2]](diffhunk://#diff-cedf94f97f1e32ff05bb71a4ebf72d9b1075f04117fa39e64ee3b513f6e48685L443-R443) [[3]](diffhunk://#diff-cedf94f97f1e32ff05bb71a4ebf72d9b1075f04117fa39e64ee3b513f6e48685L488-R489) [[4]](diffhunk://#diff-cedf94f97f1e32ff05bb71a4ebf72d9b1075f04117fa39e64ee3b513f6e48685L511-R511) [[5]](diffhunk://#diff-cedf94f97f1e32ff05bb71a4ebf72d9b1075f04117fa39e64ee3b513f6e48685L523-R523) [[6]](diffhunk://#diff-cedf94f97f1e32ff05bb71a4ebf72d9b1075f04117fa39e64ee3b513f6e48685L544-R549) [[7]](diffhunk://#diff-cedf94f97f1e32ff05bb71a4ebf72d9b1075f04117fa39e64ee3b513f6e48685L567-R567) [[8]](diffhunk://#diff-cedf94f97f1e32ff05bb71a4ebf72d9b1075f04117fa39e64ee3b513f6e48685L586-R592)