### PR TITLE
Fix forms

### DIFF
--- a/src/features/mobiles/AddMobile.tsx
+++ b/src/features/mobiles/AddMobile.tsx
@@ -1,5 +1,5 @@
 import Header from "@/components/Header"
-import { Box, Button, useTheme } from "@mui/material"
+import { Box, Button, MenuItem, TextField, useTheme } from "@mui/material"
 import React, { JSX, useState } from "react"
 import { useNavigate } from "react-router-dom"
 import { useAddMobileMutation } from "../api/apiSlice"
@@ -34,6 +34,7 @@ const initialValues: FormValues = {
   filterLength: 10,
   checkParametersInterval: 60,
   comment: "test",
+  gain: 0,
 }
 
 const AddMobile: React.FC = () => {
@@ -211,19 +212,22 @@ const AddMobile: React.FC = () => {
             fullWidth
             margin="normal"
           />
-          <TrimmedTextField
+          <TextField
             name="gain"
             label="Gain"
-            type="number"
+            select
             value={formValues.gain}
             onChange={handleChange}
             fullWidth
             margin="normal"
-          />
+          >
+            <MenuItem value={0}>0</MenuItem>
+            <MenuItem value={1}>1</MenuItem>
+            <MenuItem value={2}>2</MenuItem>
+          </TextField>
           <TrimmedTextField
             name="slope"
             label="Slope"
-            type="number"
             value={formValues.slope}
             onChange={handleChange}
             fullWidth

--- a/src/features/mobiles/EditMobile.tsx
+++ b/src/features/mobiles/EditMobile.tsx
@@ -1,5 +1,5 @@
 import Header from "@/components/Header"
-import { Box, Button, useTheme } from "@mui/material"
+import { Box, Button, MenuItem, TextField, useTheme } from "@mui/material"
 import React, { JSX, useEffect, useState } from "react"
 import { useNavigate, useParams } from "react-router-dom"
 import {
@@ -318,19 +318,22 @@ const EditMobile: React.FC = () => {
             fullWidth
             margin="normal"
           />
-          <TrimmedTextField
+          <TextField
             name="gain"
             label="Gain"
-            type="number"
+            select
             value={formValues.gain}
             onChange={handleChange}
             fullWidth
             margin="normal"
-          />
+          >
+            <MenuItem value={0}>0</MenuItem>
+            <MenuItem value={1}>1</MenuItem>
+            <MenuItem value={2}>2</MenuItem>
+          </TextField>
           <TrimmedTextField
             name="slope"
             label="Slope"
-            type="number"
             value={formValues.slope}
             onChange={handleChange}
             fullWidth


### PR DESCRIPTION
This pull request updates the handling of the `gain` field in both the Add and Edit Mobile forms to use a dropdown selector with predefined options, improving user experience and data consistency. It also imports the necessary Material UI components to support these changes.

**Form field improvements:**

* Changed the `gain` input in both `AddMobile.tsx` and `EditMobile.tsx` from a numeric input to a dropdown (`TextField` with `select`) with options 0, 1, and 2, ensuring only valid values can be selected. [[1]](diffhunk://#diff-ef81005b5bd2c034e0805ddb11a72f9941ca38a0746e51f35df97a95d61bf64fL214-L226) [[2]](diffhunk://#diff-5be5bcb11d7f7b4d742739cf4f46f589ccd69613b03ccda4b471168b4b855e48L321-L333)
* Added `MenuItem` and `TextField` imports from Material UI in both files to support the new dropdown component. [[1]](diffhunk://#diff-ef81005b5bd2c034e0805ddb11a72f9941ca38a0746e51f35df97a95d61bf64fL2-R2) [[2]](diffhunk://#diff-5be5bcb11d7f7b4d742739cf4f46f589ccd69613b03ccda4b471168b4b855e48L2-R2)

**Initial values update:**

* Set the default value of `gain` to 0 in the initial form values for the Add Mobile form.