### PR TITLE
Sort measurement data by createdAt in PerformanceChart

### DIFF
--- a/src/components/measurements/PerformanceChart.tsx
+++ b/src/components/measurements/PerformanceChart.tsx
@@ -7,7 +7,7 @@ import {
   Select,
   useTheme,
 } from "@mui/material"
-import { Grid } from "@mui/material"
+import Grid from "@mui/system/Unstable_Grid"
 import dayjs from "dayjs"
 import utc from "dayjs/plugin/utc"
 import distinctColors from "distinct-colors"
@@ -122,7 +122,18 @@ const PerformanceChart = ({ query, pageKey, dateField = "date" }: any) => {
 
   useEffect(() => {
     if (data) {
-      setMeasurements(data)
+      const reorderedData = []
+      for (const measurement of data) {
+        let sortedData = Array.from(measurement.data)
+        sortedData.sort((a: any, b: any) => {
+          return (
+            new Date(a["createdAt"]).getTime() -
+            new Date(b["createdAt"]).getTime()
+          )
+        })
+        reorderedData.push({ ...measurement, data: sortedData })
+      }
+      setMeasurements(reorderedData)
     }
   }, [data])
 


### PR DESCRIPTION
This pull request updates the `PerformanceChart` component to improve how measurement data is imported and displayed. The main changes include switching to the unstable grid system from MUI and ensuring that measurement data is sorted chronologically by the `createdAt` field before being set in state.

**UI Library Update:**
* Switched the import of `Grid` from `@mui/material` to `@mui/system/Unstable_Grid` to use the unstable grid system, which may offer more flexibility or features.

**Data Handling Improvements:**
* Updated the `useEffect` hook in `PerformanceChart` to sort each measurement's `data` array by the `createdAt` timestamp, ensuring that data points are displayed in chronological order.